### PR TITLE
Fix JS link to Contact page

### DIFF
--- a/assets/sample/src/router.jsx
+++ b/assets/sample/src/router.jsx
@@ -37,9 +37,9 @@ const Root = (props) => (
           <Link to="about" className="hover:text-zinc-700">
             About
           </Link>
-          <LiveLink patch="contact" className="hover:text-zinc-700">
+          <Link to="contact" className="hover:text-zinc-700">
             Contact
-          </LiveLink>
+          </Link>
           <LiveLink navigate="login" className="hover:text-zinc-700">
             Login
           </LiveLink>


### PR DESCRIPTION
`/contact` is part of the SPA, so it should use `<Link>` rather than `<LiveLink>`

PS: thank you for the template!